### PR TITLE
A604204973640971 swiftsure procedure

### DIFF
--- a/openregistry/lots/loki/models.py
+++ b/openregistry/lots/loki/models.py
@@ -12,7 +12,6 @@ from openregistry.lots.core.constants import (
 )
 
 from openregistry.lots.core.models import (
-    Classification,
     LokiDocument as Document,
     LokiItem as Item,
     Decision,
@@ -23,8 +22,9 @@ from openregistry.lots.core.models import (
     IsoDurationType,
     Guarantee,
     Period,
-    Value
-
+    Value,
+    BankAccount,
+    AuctionParameters
 )
 
 from openregistry.lots.core.models import ILot, Lot as BaseLot
@@ -40,7 +40,6 @@ from .constants import (
 from .roles import (
     lot_roles,
     auction_roles,
-    auctionParameters_roles
 )
 
 
@@ -50,25 +49,6 @@ class ILokiLot(ILot):
 
 class StartDateRequiredPeriod(Period):
     startDate = IsoDateTimeType(required=True)
-
-
-class UAEDRAndMFOClassification(Classification):
-    scheme = StringType(choices=['UA-EDR', 'UA-MFO', 'accountNumber'], required=True)
-
-
-class BankAccount(Model):
-    description = StringType()
-    bankName = StringType()
-    accountNumber = StringType()
-    accountIdentification = ListType(ModelType(UAEDRAndMFOClassification), default=list())
-
-
-class AuctionParameters(Model):
-    class Options:
-        roles = auctionParameters_roles
-
-    type = StringType(choices=['english', 'insider'])
-    dutchSteps = IntType(default=None, min_value=1, max_value=100)
 
 
 class Auction(Model):

--- a/openregistry/lots/loki/roles.py
+++ b/openregistry/lots/loki/roles.py
@@ -43,15 +43,6 @@ auction_roles = {
     'edit_3.sellout.insider': edit_insider
 }
 
-english_auctionParameters_edit_role = blacklist('type', 'dutchSteps')
-insider_auctionParameters_edit_role = blacklist('type')
-auctionParameters_roles = {
-    'create': blacklist('type', 'dutchSteps'),
-    'edit_1.sellout.english': english_auctionParameters_edit_role,
-    'edit_2.sellout.english': english_auctionParameters_edit_role,
-    'edit_3.sellout.insider': insider_auctionParameters_edit_role
-}
-
 lot_create_role = (whitelist('status', 'assets', 'decisions', 'lotType', 'lotIdentifier', 'mode'))
 lot_edit_role = (blacklist('owner_token', 'owner', '_attachments',
                        'revisions', 'date', 'dateModified', 'documents', 'decisions',

--- a/openregistry/lots/loki/tests/models.py
+++ b/openregistry/lots/loki/tests/models.py
@@ -128,7 +128,7 @@ class DummyModelsTest(unittest.TestCase):
         self.assertEqual(
             ex.exception.messages,
             {'auctionParameters':
-                 {'dutchSteps': [u'Int value should be less than 100.']}
+                 {'dutchSteps': [u'Int value should be less than 99.']}
             }
         )
 


### PR DESCRIPTION
Move models from lots.loki to api

### Depends on:

- https://github.com/openprocurement/openregistry.lots.core/pull/38

- https://github.com/openprocurement/openprocurement.api/pull/317